### PR TITLE
Add Logging Configuration For DriveTrain and UserInterface Classes

### DIFF
--- a/config/logging.conf
+++ b/config/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,robot
+keys=root,robot, driveTrain
 
 [handlers]
 keys=consoleHandler
@@ -17,11 +17,23 @@ handlers=robotFileHandler
 qualname=robot
 propagate=0
 
+[logger_driveTrain]
+level=DEBUG
+handlers=driveTrainFileHandler
+qualname=driveTrain
+propagate=0
+
 [handler_robotFileHandler]
 class=RotatingFileHandler
 level=DEBUG
 formatter=defaultFormatter
 args=('robot.log', 'a', 102400, 3)
+
+[handler_driveTrainFileHandler]
+class=RotatingFileHandler
+level=DEBUG
+formatter=defaultFormatter
+args=('drivetrain.log', 'a', 102400, 3)
 
 [handler_consoleHandler]
 class=StreamHandler

--- a/config/logging.conf
+++ b/config/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,robot, driveTrain
+keys=root,robot, driveTrain, userInterface
 
 [handlers]
 keys=consoleHandler
@@ -23,6 +23,12 @@ handlers=driveTrainFileHandler
 qualname=driveTrain
 propagate=0
 
+[logger_userInterface]
+level=DEBUG
+handlers=userInterfaceFileHandler
+qualname=userInterface
+propagate=0
+
 [handler_robotFileHandler]
 class=RotatingFileHandler
 level=DEBUG
@@ -34,6 +40,12 @@ class=RotatingFileHandler
 level=DEBUG
 formatter=defaultFormatter
 args=('drivetrain.log', 'a', 102400, 3)
+
+[handler_userInterfaceFileHandler]
+class=RotatingFileHandler
+level=DEBUG
+formatter=defaultFormatter
+args=('userinterface.log', 'a', 102400, 3)
 
 [handler_consoleHandler]
 class=StreamHandler


### PR DESCRIPTION
# Summary

The logging config file needs to have sections added for the drivetrain and userinterface modules.
