### PR TITLE
Fix error with logging config file

### DIFF
--- a/config/logging.conf
+++ b/config/logging.conf
@@ -1,8 +1,8 @@
 [loggers]
-keys=root,robot, driveTrain, userInterface
+keys=root,robot,driveTrain,userInterface
 
 [handlers]
-keys=consoleHandler
+keys=consoleHandler,robotFileHandler,driveTrainFileHandler,userInterfaceFileHandler
 
 [formatters]
 keys=defaultFormatter
@@ -10,6 +10,7 @@ keys=defaultFormatter
 [logger_root]
 level=DEBUG
 handlers=consoleHandler
+qualname=root
 
 [logger_robot]
 level=DEBUG
@@ -30,22 +31,22 @@ qualname=userInterface
 propagate=0
 
 [handler_robotFileHandler]
-class=RotatingFileHandler
+class=FileHandler
 level=DEBUG
 formatter=defaultFormatter
-args=('robot.log', 'a', 102400, 3)
+args=('robot.log', 'w')
 
 [handler_driveTrainFileHandler]
-class=RotatingFileHandler
+class=FileHandler
 level=DEBUG
 formatter=defaultFormatter
-args=('drivetrain.log', 'a', 102400, 3)
+args=('drivetrain.log', 'a')
 
 [handler_userInterfaceFileHandler]
-class=RotatingFileHandler
+class=FileHandler
 level=DEBUG
 formatter=defaultFormatter
-args=('userinterface.log', 'a', 102400, 3)
+args=('userinterface.log', 'a')
 
 [handler_consoleHandler]
 class=StreamHandler


### PR DESCRIPTION
# Summary

The RotatingFileHandler handler type doesn't seem to be recognized. Also, the handlers are missing from the handler keys variable.
