### PR TITLE
Add Ability To Spin Trash Bins With Feeder Arms

### DIFF
--- a/src/robot/feeder.py
+++ b/src/robot/feeder.py
@@ -310,6 +310,12 @@ class Feeder(object):
         elif direction == common.Direction.OUT:
             right_direction = common.Direction.CLOCKWISE
             left_direction = common.Direction.COUNTERCLOCKWISE
+        elif direction == common.Direction.CLOCKWISE:
+            right_direction = common.Direction.CLOCKWISE
+            left_direction = common.Direction.CLOCKWISE
+        elif direction == common.Direction.COUNTERCLOCKWISE:
+            right_direction = common.Direction.COUNTERCLOCKWISE
+            left_direction = common.Direction.COUNTERCLOCKWISE
         elif direction == common.Direction.STOP:
             right_direction = common.Direction.STOP
             left_direction = common.Direction.STOP

--- a/src/robot/feeder.py
+++ b/src/robot/feeder.py
@@ -274,6 +274,12 @@ class Feeder(object):
             elif direction == common.Direction.OUT:
                 self._right_arm.spin(common.Direction.CLOCKWISE, speed)
                 self._left_arm.spin(common.Direction.COUNTERCLOCKWISE, speed)
+            elif direction == common.Direction.CLOCKWISE:
+                self._right_arm.spin(common.Direction.CLOCKWISE, speed)
+                self._left_arm.spin(common.Direction.CLOCKWISE, speed)
+            elif direction == common.Direction.COUNTERCLOCKWISE:
+                self._right_arm.spin(common.Direction.COUNTERCLOCKWISE, speed)
+                self._left_arm.spin(common.Direction.COUNTERCLOCKWISE, speed)
             elif direction == common.Direction.STOP:
                 self._right_arm.spin(common.Direction.STOP, 0)
                 self._left_arm.spin(common.Direction.STOP, 0)


### PR DESCRIPTION
# Summary

The feeder arms should be able to rotate a trash bin by spinning the wheels in the same direction (instead of the typical opposing directions used when feeding an object).
